### PR TITLE
Commenting out line 16 of corpusBuilderServer.js allows the application

### DIFF
--- a/CI_Corpus_Builder/server/corpusBuilderServer.js
+++ b/CI_Corpus_Builder/server/corpusBuilderServer.js
@@ -13,7 +13,7 @@ var tempfile="tempfile.zip";
 var labelTag="<H1>"; //UPPERCASE! Search the doc for this tag to make the label
 
 var fs = Npm.require('fs');
-//var AdmZip = Npm.require('adm-zip');
+var AdmZip = Npm.require('adm-zip');
 var zipDocs = new Mongo.Collection(null);
 var go=true; // change this flag to false to abandon processing
 


### PR DESCRIPTION
to be deployed, but of course won't run like that.
